### PR TITLE
Added missing easydict requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ git+https://github.com/qubvel/segmentation_models.pytorch
 timm>=0.4
 imgaug
 ml_collections
+easydict


### PR DESCRIPTION
Got:

```
segtran/code/train2d.py:947: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if args.task_name == 'fundus' and args.vcdr_estim_scheme is not 'none':
Traceback (most recent call last):
  File "/Users/niklasqnielsen/workspace/aidb.dev/segtran/code/train2d.py", line 36, in <module>
    from networks.polyformer import Polyformer, PolyformerLayer
  File "/Users/niklasqnielsen/workspace/aidb.dev/segtran/code/networks/polyformer.py", line 4, in <module>
    from easydict import EasyDict as edict
ModuleNotFoundError: No module named 'easydict'
```